### PR TITLE
VG-9389: Adding system prop to set http redirect strategy, allowing POST by default

### DIFF
--- a/modules/plugin/http-commons/pom.xml
+++ b/modules/plugin/http-commons/pom.xml
@@ -21,6 +21,7 @@
   <!-- =========================================================== -->
   <groupId>org.geotools</groupId>
   <artifactId>gt-http-commons</artifactId>
+  <version>26.3.VG1</version>
   <packaging>jar</packaging>
   <name>HTTP Client based on Apache Commons HttpClient</name>
 
@@ -52,12 +53,12 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-main</artifactId>
-      <version>${project.version}</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-http</artifactId>
-      <version>${project.version}</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/modules/plugin/http-commons/src/main/java/org/geotools/http/commons/MultithreadedHttpClient.java
+++ b/modules/plugin/http-commons/src/main/java/org/geotools/http/commons/MultithreadedHttpClient.java
@@ -16,6 +16,8 @@
  */
 package org.geotools.http.commons;
 
+import static org.apache.commons.lang3.StringUtils.split;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,6 +45,7 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.geotools.data.ows.AbstractOpenWebService;
@@ -106,6 +109,14 @@ public class MultithreadedHttpClient implements HTTPClient, HTTPConnectionPoolin
                                         GeoTools.getVersion(), this.getClass().getSimpleName()))
                         .useSystemProperties()
                         .setConnectionManager(connectionManager);
+
+        String[] supportedProtocols = split(System.getProperty("geotools.http.redirect.strategy"));
+        if (supportedProtocols != null) {
+            builder.setRedirectStrategy(new DefaultRedirectStrategy(supportedProtocols));
+        } else {
+            // VG-9389 : allow GET, HEAD and POST to be redirected by default:
+            builder.setRedirectStrategy(new DefaultRedirectStrategy(new String[] {"GET", "HEAD", "POST"}));
+        }
         if (credsProvider != null) {
             builder.setDefaultCredentialsProvider(credsProvider);
         }


### PR DESCRIPTION
The issue is that some WFS uses POST with redirecting from HTTPS to HTTP  (e.g. https://opendata.maps.vic.gov.au/geoserver/ows/wfs?service=WFS&request=GetCapabilities&version=2.0.0). I tried to add just a hook and allow to set this in the Connector but that seems to require several hoops to jump through (adding custom WFSFactory etc...). This should require just update the version in voyager and all should just work.